### PR TITLE
Wrap CMD in `exec`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,5 +17,5 @@ ENV AWS_ADDRESS s3.amazonaws.com
 ENV BUCKET_ADDRESS com.ft.imagepublish.int
 EXPOSE 8080
 
-CMD cd / && /synth-publication -dynRouting=$DYN_ROUTING -postHost=$POST_ADDRESS -postCredentials="$POST_CREDENTIALS" -s3Host=$BUCKET_ADDRESS.$AWS_ADDRESS -testUuid=$TEST_UUID
+CMD exec /synth-publication -dynRouting=$DYN_ROUTING -postHost=$POST_ADDRESS -postCredentials="$POST_CREDENTIALS" -s3Host=$BUCKET_ADDRESS.$AWS_ADDRESS -testUuid=$TEST_UUID
 


### PR DESCRIPTION
Docker will spawn a shell for the process if the CMD is writted in
"shell form". Wrapping the command in exec gives app pid 1:

```
~/docker exec -ti test-sipm ps
PID   USER     TIME   COMMAND
    1 root       0:00 /synth-publication -dynRouting=false
-postHost=test -postCredentials=test -s3Host=test.test -testUuid=test
   35 root       0:00 ps
```

which should handle better sigterm/sigkill commands from docker