### PR TITLE
Increase check interval to 60 sec.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+coco-synthetic-image-publication-monitor

--- a/synth-publish.go
+++ b/synth-publish.go
@@ -16,7 +16,10 @@ import (
 	"time"
 )
 
-const stateCheckInterval = time.Duration(60) * time.Second
+const (
+	stateCheckInterval = time.Duration(60) * time.Second
+ 	postInterval = time.Duration(120) * time.Second
+)
 
 type syntheticPublication struct {
 	postEndpoint      string
@@ -66,7 +69,7 @@ func main() {
 	}
 
 	if *tick {
-		tick := time.Tick(time.Minute)
+		tick := time.Tick(postInterval)
 		go func() {
 			for {
 				app.publish()

--- a/synth-publish.go
+++ b/synth-publish.go
@@ -156,7 +156,6 @@ func (app *syntheticPublication) publish() error {
 		req.Host = "cms-notifier"
 	}
 
-	log.Printf("Sending publishing request %s", tid)
 	resp, err := client.Do(req)
 	if err != nil {
 		log.Printf("Error: Executing request failed. %s", err.Error())
@@ -215,7 +214,7 @@ func checkPublishingStatus(latest postedData, result chan<- publicationResult, s
 		handlePublishingErr(result, latest.tid, latest.time, "Posted image content differs from the image in s3.")
 		return
 	}
-	log.Printf("Received publication result for %s", latest.tid)
+	
 	result <- publicationResult{latest.tid, latest.time, true, ""}
 }
 

--- a/synth-publish.go
+++ b/synth-publish.go
@@ -156,6 +156,7 @@ func (app *syntheticPublication) publish() error {
 		req.Host = "cms-notifier"
 	}
 
+	log.Printf("Sending publishing request %s", tid)
 	resp, err := client.Do(req)
 	if err != nil {
 		log.Printf("Error: Executing request failed. %s", err.Error())
@@ -214,6 +215,7 @@ func checkPublishingStatus(latest postedData, result chan<- publicationResult, s
 		handlePublishingErr(result, latest.tid, latest.time, "Posted image content differs from the image in s3.")
 		return
 	}
+	log.Printf("Received publication result for %s", latest.tid)
 	result <- publicationResult{latest.tid, latest.time, true, ""}
 }
 

--- a/synth-publish.go
+++ b/synth-publish.go
@@ -16,6 +16,8 @@ import (
 	"time"
 )
 
+const stateCheckInterval = time.Duration(60) * time.Second
+
 type syntheticPublication struct {
 	postEndpoint      string
 	postCredentials   string
@@ -181,7 +183,7 @@ func checkPublishingStatus(latest postedData, result chan<- publicationResult, s
 		handlePublishingErr(result, latest.tid, latest.time, internalErr+"Decoding image received from channed failed. "+err.Error())
 		return
 	}
-	time.Sleep(30 * time.Second)
+	time.Sleep(stateCheckInterval)
 	resp, err := http.Get(s3Endpoint)
 	if err != nil {
 		handlePublishingErr(result, latest.tid, latest.time, internalErr+"Executing Get request to s3 failed. "+err.Error())


### PR DESCRIPTION
Context:
We've recently received more frequently Image Publish Pingdom Alerts for prod-us and prod-uk.
We've identified the only service in a warning state was the synthetic monitor. The publishes get into the store, they are just slower sometimes.

Potential fix:
The service was checking the image's presence after 30 sec. We have 2 min in our SLA's enabled, so I think an increase to 60 sec could help.

Status:
Needs to be tested in lower envs.