### PR TITLE
Separate test image uuid for devcj

### DIFF
--- a/helm/synthetic-image-publication-monitor/app-configs/synthetic-image-publication-monitor_delivery_devcj.yaml
+++ b/helm/synthetic-image-publication-monitor/app-configs/synthetic-image-publication-monitor_delivery_devcj.yaml
@@ -3,4 +3,4 @@ replicaCount: 1
 service:
   name: synthetic-image-publication-monitor
 env:
-  imageUuid: "6a70679a-fd9b-4d64-9bec-2d340fb75021"
+  imageUuid: "7a70679a-fd9b-4d64-9bec-2d340fb75021"

--- a/helm/synthetic-image-publication-monitor/templates/deployment.yaml
+++ b/helm/synthetic-image-publication-monitor/templates/deployment.yaml
@@ -41,7 +41,7 @@ spec:
               name: global-config 
               key: aws.s3.image.binaries.bucket
         - name: TEST_UUID
-          value: "6a70679a-fd9b-4d64-9bec-2d340fb75021"
+          value: "{{ .Values.env.imageUuid }}"
         ports: 
         - containerPort: 8080 
         livenessProbe: 

--- a/helm/synthetic-image-publication-monitor/values.yaml
+++ b/helm/synthetic-image-publication-monitor/values.yaml
@@ -12,5 +12,5 @@ resources:
     memory: 8Mi
   limits:
     memory: 72Mi
-
-
+env:
+  imageUuid: "" # This should be defined in the specific app-configs folder


### PR DESCRIPTION
Quick fix, we should probably want to move the configuration to `global-configs`.